### PR TITLE
Feat/brick conf read

### DIFF
--- a/example/exeiac.yml
+++ b/example/exeiac.yml
@@ -1,5 +1,5 @@
 modules:
-  - name: module_test
+  - name: test
     path: /home/ME/git-repos/exeiac-modules/module_test.sh
   - name: terraform
     path: /home/ME/git-repos/exeiac-modules/terraform

--- a/example/repos/infra-grounds/2-envs/1-production/1-network/brick.yml
+++ b/example/repos/infra-grounds/2-envs/1-production/1-network/brick.yml
@@ -5,11 +5,11 @@ input:
     path: .env
     data:
       - name: env_name
-        from: infra-ground/1-init:.production.name
+        from: infra-ground/1-init:$.production.name
       - name: env_project_name
-        from: infra-ground/1-init:.production.project
+        from: infra-ground/1-init:$.production.project
       - name: env_user_name
-        from: infra-ground/1-init:.production.credentials.user
+        from: infra-ground/1-init:$.production.credentials.user
       - name: env_credentials
-        from: infra-ground/1-init:.production.credentials.key
+        from: infra-ground/1-init:$.production.credentials.key
     

--- a/example/repos/infra-grounds/2-envs/1-production/2-bastion/brick.yml
+++ b/example/repos/infra-grounds/2-envs/1-production/2-bastion/brick.yml
@@ -5,18 +5,18 @@ input:
     path: .env
     data:
       - name: env_name
-        from: infra-ground/1-init:.production.name
+        from: infra-ground/1-init:$.production.name
       - name: env_project_name
-        from: infra-ground/1-init:.production.project
+        from: infra-ground/1-init:$.production.project
       - name: env_user_name
-        from: infra-ground/1-init:.production.credentials.user
+        from: infra-ground/1-init:$.production.credentials.user
       - name: env_credentials
-        from: infra-ground/1-init:.production.credentials.key
+        from: infra-ground/1-init:$.production.credentials.key
       - name: network_ip_range
-        from: infra-ground/2-envs/1-production/1-network:.network.ip_range
+        from: infra-ground/2-envs/1-production/1-network:$.network.ip_range
       - name: network_id
-        from: infra-ground/2-envs/1-production/1-network:.network.network_id
+        from: infra-ground/2-envs/1-production/1-network:$.network.network_id
       - name: internal_domain
-        from: infra-ground/2-envs/1-production/1-network:.domain_name.internal
+        from: infra-ground/2-envs/1-production/1-network:$.domain_name.internal
       - name: private_domain
-        from: infra-ground/2-envs/1-production/1-network:.domain_name.private
+        from: infra-ground/2-envs/1-production/1-network:$.domain_name.private

--- a/example/repos/infra-grounds/2-envs/1-staging/1-network/brick.yml
+++ b/example/repos/infra-grounds/2-envs/1-staging/1-network/brick.yml
@@ -5,11 +5,11 @@ input:
     path: .env
     data:
       - name: env_name
-        from: infra-ground/1-init:.staging.name
+        from: infra-ground/1-init:$.staging.name
       - name: env_project_name
-        from: infra-ground/1-init:.staging.project
+        from: infra-ground/1-init:$.staging.project
       - name: env_user_name
-        from: infra-ground/1-init:.staging.credentials.user
+        from: infra-ground/1-init:$.staging.credentials.user
       - name: env_credentials
-        from: infra-ground/1-init:.staging.credentials.key
+        from: infra-ground/1-init:$.staging.credentials.key
     

--- a/example/repos/infra-grounds/2-envs/1-staging/2-bastion/brick.yml
+++ b/example/repos/infra-grounds/2-envs/1-staging/2-bastion/brick.yml
@@ -5,18 +5,18 @@ input:
     path: .env
     data:
       - name: env_name
-        from: infra-ground/1-init:.staging.name
+        from: infra-ground/1-init:$.staging.name
       - name: env_project_name
-        from: infra-ground/1-init:.staging.project
+        from: infra-ground/1-init:$.staging.project
       - name: env_user_name
-        from: infra-ground/1-init:.staging.credentials.user
+        from: infra-ground/1-init:$.staging.credentials.user
       - name: env_credentials
-        from: infra-ground/1-init:.staging.credentials.key
+        from: infra-ground/1-init:$.staging.credentials.key
       - name: network_ip_range
-        from: infra-ground/2-envs/1-staging/1-network:.network.ip_range
+        from: infra-ground/2-envs/1-staging/1-network:$.network.ip_range
       - name: network_id
-        from: infra-ground/2-envs/1-staging/1-network:.network.network_id
+        from: infra-ground/2-envs/1-staging/1-network:$.network.network_id
       - name: internal_domain
-        from: infra-ground/2-envs/1-staging/1-network:.domain_name.internal
+        from: infra-ground/2-envs/1-staging/1-network:$.domain_name.internal
       - name: private_domain
-        from: infra-ground/2-envs/1-staging/1-network:.domain_name.private
+        from: infra-ground/2-envs/1-staging/1-network:$.domain_name.private

--- a/example/repos/infra-grounds/2-envs/2-monitoring/1-network/brick.yml
+++ b/example/repos/infra-grounds/2-envs/2-monitoring/1-network/brick.yml
@@ -5,11 +5,11 @@ input:
     path: .env
     data:
       - name: env_name
-        from: infra-ground/1-init:.monitoring.name
+        from: infra-ground/1-init:$.monitoring.name
       - name: env_project_name
-        from: infra-ground/1-init:.monitoring.project
+        from: infra-ground/1-init:$.monitoring.project
       - name: env_user_name
-        from: infra-ground/1-init:.monitoring.credentials.user
+        from: infra-ground/1-init:$.monitoring.credentials.user
       - name: env_credentials
-        from: infra-ground/1-init:.monitoring.credentials.key
+        from: infra-ground/1-init:$.monitoring.credentials.key
     

--- a/example/repos/infra-grounds/2-envs/2-monitoring/2-bastion/brick.yml
+++ b/example/repos/infra-grounds/2-envs/2-monitoring/2-bastion/brick.yml
@@ -5,18 +5,18 @@ input:
     path: .env
     data:
       - name: env_name
-        from: infra-ground/1-init:.monitoring.name
+        from: infra-ground/1-init:$.monitoring.name
       - name: env_project_name
-        from: infra-ground/1-init:.monitoring.project
+        from: infra-ground/1-init:$.monitoring.project
       - name: env_user_name
-        from: infra-ground/1-init:.monitoring.credentials.user
+        from: infra-ground/1-init:$.monitoring.credentials.user
       - name: env_credentials
-        from: infra-ground/1-init:.monitoring.credentials.key
+        from: infra-ground/1-init:$.monitoring.credentials.key
       - name: network_ip_range
-        from: infra-ground/2-envs/2-monitoring/1-network:.network.ip_range
+        from: infra-ground/2-envs/2-monitoring/1-network:$.network.ip_range
       - name: network_id
-        from: infra-ground/2-envs/2-monitoring/1-network:.network.network_id
+        from: infra-ground/2-envs/2-monitoring/1-network:$.network.network_id
       - name: internal_domain
-        from: infra-ground/2-envs/2-monitoring/1-network:.domain_name.internal
+        from: infra-ground/2-envs/2-monitoring/1-network:$.domain_name.internal
       - name: private_domain
-        from: infra-ground/2-envs/2-monitoring/1-network:.domain_name.private
+        from: infra-ground/2-envs/2-monitoring/1-network:$.domain_name.private

--- a/src/go.mod
+++ b/src/go.mod
@@ -2,4 +2,8 @@ module src/exeiac
 
 go 1.19
 
-require gopkg.in/yaml.v2 v2.4.0 // indirect
+require (
+	github.com/PaesslerAG/gval v1.0.0 // indirect
+	github.com/PaesslerAG/jsonpath v0.1.1 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
+)

--- a/src/go.sum
+++ b/src/go.sum
@@ -1,3 +1,8 @@
+github.com/PaesslerAG/gval v1.0.0 h1:GEKnRwkWDdf9dOmKcNrar9EA1bz1z9DqPIO1+iLzhd8=
+github.com/PaesslerAG/gval v1.0.0/go.mod h1:y/nm5yEyTeX6av0OfKJNp9rBNj2XrGhAf5+v24IBN1I=
+github.com/PaesslerAG/jsonpath v0.1.0/go.mod h1:4BzmtoM/PI8fPO4aQGIusjGxGir2BzcV0grWtFzq1Y8=
+github.com/PaesslerAG/jsonpath v0.1.1 h1:c1/AToHQMVsduPAa4Vh6xp2U0evy4t8SWp8imEsylIk=
+github.com/PaesslerAG/jsonpath v0.1.1/go.mod h1:lVboNxFGal/VwW6d9JzIy56bUsYAP6tH/x80vjnCseY=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=

--- a/src/infra/brick.go
+++ b/src/infra/brick.go
@@ -135,6 +135,7 @@ func (bcy BrickConfYaml) getDependencies(infra *Infra) ([]Dependency, error) {
 				return dependencies, err
 			}
 
+			// NOTE(half-shell): We make sure the jsonPath's form is valid
 			jsonPath, err := jsonpath.New(keyPath)
 			if err != nil {
 				return dependencies, err

--- a/src/infra/brick.go
+++ b/src/infra/brick.go
@@ -10,4 +10,11 @@ type Brick struct {
 	// Wheither or not the brick contains a `brick.yml` file.
 	// Meaning it does not contain any other brick.
 	IsElementary bool
+func (brick *Brick) SetElementary(cfp string) *Brick {
+	brick.IsElementary = true
+	brick.ConfigurationFilePath = cfp
+
+	return brick
+}
+
 }

--- a/src/infra/brick.go
+++ b/src/infra/brick.go
@@ -1,5 +1,24 @@
 package infra
 
+import (
+	"errors"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+
+	"gopkg.in/yaml.v2"
+)
+
+type Dependency struct {
+	// A reference to the related brick
+	Brick *Brick
+	// The name the variable is supposed to take
+	VarName string
+	// The JSON path to access the variable
+	JsonPath string
+}
+
 type Brick struct {
 	// The brick's name. Usually the name of the parent directory
 	Name string
@@ -10,6 +29,63 @@ type Brick struct {
 	// Wheither or not the brick contains a `brick.yml` file.
 	// Meaning it does not contain any other brick.
 	IsElementary bool
+	// A pointer to a module
+	Module *Module
+	// Pointer to the bricks it depends on
+	Dependencies []Dependency
+}
+
+type BrickConfYaml struct {
+	// The configuration file's format version
+	Version string `yaml:"version"`
+	// The name or path of the module it uses
+	Module string `yaml:"module"`
+	// A slice of different kinds of input needed for this brick
+	// It **usually** matches the plain or processed output of another brick
+	Input []struct {
+		// The type of input this brick is expecting
+		// Can match the strings "env_file" or "env_var"
+		Type string `yaml:"type"`
+		// If the type is a path, it is the path the dependency output should be saved to
+		Path string `yaml:"path"`
+		Data []struct {
+			// The name the variable is expected to have
+			Name string `yaml:"name"`
+			// The key path the input variable should match
+			// It is of the form "<brick_name>:"<json_path>"
+			// OR "<brick_path>:"<json_path>"
+			// e.g. "super-brick/brick:.object.field
+			From string `yaml:"from"`
+		}
+	} `yaml:"input"`
+}
+
+// Reads a the yaml configuration file and parses it.
+// Returns the parsed configuration.
+// Returns an error because of reading or parsing the file.
+func (bcy BrickConfYaml) New(path string) (BrickConfYaml, error) {
+	in, err := os.ReadFile(path)
+	if err != nil {
+		return BrickConfYaml{}, err
+	}
+
+	err = yaml.Unmarshal(in, &bcy)
+	if err != nil {
+		return BrickConfYaml{}, err
+	}
+
+	return bcy, nil
+}
+
+func (brick Brick) String() string {
+	return fmt.Sprintf("Name: %s, Path: %s, ConfigurationFilePath: %s, IsElementary: %t, Module: %v",
+		brick.Name,
+		brick.Path,
+		brick.ConfigurationFilePath,
+		brick.IsElementary,
+		brick.Module)
+}
+
 func (brick *Brick) SetElementary(cfp string) *Brick {
 	brick.IsElementary = true
 	brick.ConfigurationFilePath = cfp
@@ -17,4 +93,50 @@ func (brick *Brick) SetElementary(cfp string) *Brick {
 	return brick
 }
 
+// Processes the relevant parts of a brick's configuration and updates the brick itself
+// with it.
+func (brick *Brick) Enrich(bcy BrickConfYaml, infra *Infra) (*Brick, error) {
+	if !brick.IsElementary {
+		return brick, errors.New("Cannot enrich a non-elementary brick")
+	}
+
+	module, err := GetModule(bcy.Module, &infra.Modules)
+	if err != nil {
+		return brick, err
+	}
+
+	brick.Module = module
+	dependencies, err := bcy.getDependencies(infra)
+	if err != nil {
+		log.Println("An error occured when getting dependencies: ", err)
+	}
+	brick.Dependencies = dependencies
+
+	return brick, nil
+}
+
+func (bcy BrickConfYaml) getDependencies(infra *Infra) ([]Dependency, error) {
+	var dependencies []Dependency
+	parseFromField := func(from string) (brickName string, dataKey string) {
+		fields := strings.Split(from, ":")
+
+		return fields[0], fields[1]
+	}
+
+	for _, i := range bcy.Input {
+		for _, d := range i.Data {
+			brickName, jsonPath := parseFromField(d.From)
+			// NOTE(half-shell): We sanitize the brick name here in case they turn
+			// out to be brick paths
+			brick, _ := GetBrick(sanitizeBrickName(brickName), &infra.Bricks)
+
+			dependencies = append(dependencies, Dependency{
+				Brick:    brick,
+				VarName:  d.Name,
+				JsonPath: jsonPath,
+			})
+		}
+	}
+
+	return dependencies, nil
 }

--- a/src/infra/infra.go
+++ b/src/infra/infra.go
@@ -52,7 +52,7 @@ func (i Infra) New(
 		// get all room's bricks
 		err := appendBricks(r, &i.Bricks)
 		if err != nil {
-			fmt.Println("%v\n> Warning63724ff3:infra/CreateInfra:"+
+			fmt.Printf("%v\n> Warning63724ff3:infra/CreateInfra:"+
 				"can't add bricks of this room: %s", err, r.Path)
 		}
 	}

--- a/src/infra/infra.go
+++ b/src/infra/infra.go
@@ -81,12 +81,12 @@ func appendBricks(room extools.NamePathBinding, bricks *[]Brick) error {
 				log.Fatal(err)
 			}
 
-			lastBrick := func() Brick {
+			lastBrick := func() *Brick {
 				if len(*bricks) > 0 {
-					return (*bricks)[len(*bricks)-1]
+					return &(*bricks)[len(*bricks)-1]
 				}
 
-				return Brick{}
+				return &Brick{}
 			}()
 
 			// A brick can just be described as a sub-path of a room, containing a prefixed folder name with digits, and split with a hypen ("-")
@@ -107,7 +107,6 @@ func appendBricks(room extools.NamePathBinding, bricks *[]Brick) error {
 			// An elementary brick has prefixed folder name, and a brick.yml file.
 			// TODO(half-shell): Make the configuration filename more flexible.
 			if d.Type().IsRegular() && d.Name() == "brick.yml" {
-				lastBrick := &((*bricks)[len(*bricks)-1])
 				brickName := filepath.Join(room.Name, filepath.Dir(brickRelPath))
 				name := sanitizeBrickName(brickName)
 

--- a/src/infra/infra.go
+++ b/src/infra/infra.go
@@ -1,6 +1,7 @@
 package infra
 
 import (
+	"errors"
 	"fmt"
 	"io/fs"
 	"log"
@@ -37,7 +38,7 @@ func (e ErrBrickNotFound) Error() string {
 
 func (i Infra) New(
 	rooms []extools.NamePathBinding,
-	modules []extools.NamePathBinding) (Infra, error) {
+	modules []extools.NamePathBinding) (*Infra, error) {
 
 	// create Modules
 	for _, m := range modules {
@@ -57,7 +58,7 @@ func (i Infra) New(
 		}
 	}
 
-	return i, nil
+	return &i, nil
 }
 
 var hasDigitPrefixRegexp = regexp.MustCompile(`.*/\d+-\w+$`)
@@ -174,4 +175,26 @@ func (i Infra) GetSubBricksIndexes(brickIndex int) (indexes []int) {
 	}
 	return // should not reach this point if brickIndex correspond to a superBrick
 	// but at least it's not false the subBrick of an elemenatry brick is nil
+}
+
+// TODO(half-shell): Can use a generic argument and be merged with
+// `GetBrick`
+func GetModule(name string, modules *[]Module) (*Module, error) {
+	for i, m := range *modules {
+		if m.Name == name {
+			return &(*modules)[i], nil
+		}
+	}
+
+	return nil, errors.New("No matching module name")
+}
+
+func GetBrick(name string, bricks *[]Brick) (*Brick, error) {
+	for i, b := range *bricks {
+		if b.Name == name {
+			return &(*bricks)[i], nil
+		}
+	}
+
+	return nil, errors.New("No matching module name")
 }

--- a/src/infra/infra.go
+++ b/src/infra/infra.go
@@ -110,10 +110,11 @@ func appendBricks(room extools.NamePathBinding, bricks *[]Brick) error {
 				brickName := filepath.Join(room.Name, filepath.Dir(brickRelPath))
 				name := sanitizeBrickName(brickName)
 
-				// Do not duplicate entries
+				// Set the last brick as elementary if names match
+				// This happens because it means that the parent brick is not a "super-brick"
+				// but an elementary brick
 				if lastBrick.Name == name {
-					lastBrick.IsElementary = true
-					lastBrick.ConfigurationFilePath = path
+					lastBrick.SetElementary(path)
 				}
 			}
 

--- a/src/infra/module.go
+++ b/src/infra/module.go
@@ -20,10 +20,19 @@ type Module struct {
 	Actions []string
 }
 
-func (module *Module) LoadAvailableActions() Module {
+// Executes the ACTION_SHOW_AVAILABLE_ACTIONS command on a module to get
+// the available actions from the module. Then parses and saves them in the
+// *Actions* slice.
+// If the *Actions* slice is not empty, bypass the call the the command.
+// NOTE(half-shell): Do we have a use to force the call to be triggered again here?
+func (module *Module) LoadAvailableActions() (*Module, error) {
+	if len(module.Actions) > 0 {
+		return module, nil
+	}
+
 	path, err := exec.LookPath(module.Path)
 	if err != nil {
-		log.Fatal(err)
+		return module, err
 	}
 
 	cmd := exec.Cmd{
@@ -43,5 +52,5 @@ func (module *Module) LoadAvailableActions() Module {
 		module.Actions = append(module.Actions, string(action))
 	}
 
-	return *module
+	return module, nil
 }

--- a/src/infra/module.go
+++ b/src/infra/module.go
@@ -49,7 +49,9 @@ func (module *Module) LoadAvailableActions() (*Module, error) {
 	}
 
 	for _, action := range bytes.Split(output, []byte("\n")) {
-		module.Actions = append(module.Actions, string(action))
+		if len(action) > 0 {
+			module.Actions = append(module.Actions, string(action))
+		}
 	}
 
 	return module, nil

--- a/src/main.go
+++ b/src/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"log"
 	"os"
 	exactions "src/exeiac/actions"
 	exargs "src/exeiac/arguments"
@@ -35,5 +36,18 @@ func main() {
 			"unable to get the executionPlan\n", err)
 		os.Exit(1)
 	}
+
+	for _, ep := range executionPlan {
+		if ep.Brick.IsElementary {
+			conf, err := exinfra.BrickConfYaml{}.New(ep.Brick.ConfigurationFilePath)
+			if err != nil {
+				log.Fatal("An issue happened while reading bricks' configurations\n", err)
+			}
+
+			ep.Brick.Enrich(conf, infra)
+			ep.Brick.Module.LoadAvailableActions()
+		}
+	}
+
 	executionPlan.PrintPlan()
 }

--- a/src/main.go
+++ b/src/main.go
@@ -29,7 +29,7 @@ func main() {
 	infra.Display()
 
 	// build executionPlan
-	executionPlan, err := exexec.ExecutionPlan{}.New(&infra, &args)
+	executionPlan, err := exexec.ExecutionPlan{}.New(infra, &args)
 	if err != nil {
 		fmt.Printf("%v\n> Error6373c57e:main/main: "+
 			"unable to get the executionPlan\n", err)


### PR DESCRIPTION
# Feat
* Get a module's available actions for the brick's module in the execution plan
* Read a brick's configuration and enrich it for each execution plan's brick

# Refactor
* infra.New() to have a single sway of obtaining the last brick
* Have a consistent way of defining a brick as elementary with `brick.SetElementary()`

# Fix
* Naming missmatch in sample files (module name)
* JSON key path to become an actual JSONpath
* `fmt.Println()` statement to actually output its argument
* Prevent panicking if module's path does not exist when trying to look it up and propagate error instead
* Prevent the addition of an empty action when loading a module's actions