### PR TITLE
feat: simplify the formatter definition to better fit its usage

### DIFF
--- a/src/actions/common.go
+++ b/src/actions/common.go
@@ -57,7 +57,8 @@ func enrichDatas(bricksToExecute exinfra.Bricks, infra *exinfra.Infra) error {
 					return err
 				}
 
-				_, err = formatter.Write(f)
+				data, err := formatter.Format()
+				_, err = f.Write(data)
 				if err != nil {
 					return err
 				}

--- a/src/infra/brick.go
+++ b/src/infra/brick.go
@@ -198,9 +198,9 @@ func (b *Brick) CreateFormatters() (formatters map[string]Formatter, err error) 
 		for path, vals := range paths {
 			switch format {
 			case "json":
-				formatters[path] = JsonFormat{Inputs: vals}
+				formatters[path] = JsonFormat(vals)
 			case "env_file":
-				formatters[path] = EnvFormat{Inputs: vals}
+				formatters[path] = EnvFormat(vals)
 			default:
 				// TODO(half-shell): One way of dealing with inputs passed around as environment variables
 				// would be to check for a path, and if none is present, just return on for a path of `env`

--- a/src/infra/formatters.go
+++ b/src/infra/formatters.go
@@ -3,62 +3,27 @@ package infra
 import (
 	"bytes"
 	"fmt"
-	"os"
 )
 
-// TODO(half-shell): Change naming; it sucks.
-// A formatter is an interface that allows to write to a file a representation of
-// a set of key/value pairs.
-// Sample formatters differ from the data format they write to the file to.
-// NOTE(half-shell): Should this just be a struct with different member functions
-// for each format?
-//
-//	type Formatter struct {
-//		Inputs map[string]interface{}
-//	}
-//
-// func (f Formatter) ToJSON() []byte {}
-// func (f Formatter) toYAML() []byte {}
-// func (f Formatter) toEnvFile() []byte {}
-// func (f Formatter) toEnvVars() []string {}
+// A formatter is an interface that allows to produce an output in a specific format.
 type Formatter interface {
-	Write(f *os.File) (n int, err error)
-	// NOTE(half-shel): String representation of the inputs.
-	// Each element in the slice are considered to be a line on their own.
-	String() (input []string)
+	Format() (input []byte, err error)
 }
 
-type JsonFormat struct {
-	Inputs map[string]interface{}
-}
+type JsonFormat map[string]interface{}
+type EnvFormat map[string]interface{}
 
-func (i JsonFormat) Write(f *os.File) (n int, err error) {
+func (i JsonFormat) Format() (input []byte, err error) {
 	return
 }
 
-func (i JsonFormat) String() (input []string) {
-	return
-}
-
-type EnvFormat struct {
-	Inputs map[string]interface{}
-}
-
-func (i EnvFormat) Write(f *os.File) (n int, err error) {
+func (i EnvFormat) Format() (input []byte, err error) {
 	buf := new(bytes.Buffer)
-	for varName, varVal := range i.Inputs {
+	for varName, varVal := range i {
 		buf.WriteString(fmt.Sprintf("%s=\"%v\"\n", varName, varVal))
 	}
 
-	n, err = f.Write(buf.Bytes())
-
-	return
-}
-
-func (i EnvFormat) String() (input []string) {
-	for varName, varVal := range i.Inputs {
-		input = append(input, fmt.Sprintf("%s=\"%v\"", varName, varVal))
-	}
+	input = buf.Bytes()
 
 	return
 }


### PR DESCRIPTION
# Dumb down the `Formatter` interface
* This change made it because it felt better for the `Formatter` to only have the responsibility of **HOW** is the data produced (what format), instead of taking the file writing one as well.
* Also removed a layer of nesting by going from a struct to a plain type instead
# Implications
The implications down the line are that we de-couple the formatting side of things with how they're propagated. It increases flexibility, and as shown in this PR's diff, the change is *very* minimal overall.