### PR TITLE
Feat/add show usage

### DIFF
--- a/src/actions/common.go
+++ b/src/actions/common.go
@@ -16,15 +16,15 @@ import (
 var BehaviourMap = map[string]func(*exinfra.Infra, *exargs.Configuration, exinfra.Bricks) (int, error){
 	"clean":         Clean,
 	"help":          Help,
-	"init":          Default,
+	"init":          PassthroughAction,
 	"lay":           Lay,
 	"plan":          Plan,
 	"remove":        Remove,
 	"show":          Show,
-	"validate_code": Default,
+	"validate_code": PassthroughAction,
 	"debug_args":    DebugArgs,
 	"debug_infra":   DebugInfra,
-	"default":       Default,
+	"default":       PassthroughAction,
 }
 
 const TAG_OK = "OK"
@@ -96,7 +96,6 @@ func (es ExecSummary) String() string {
 }
 
 func enrichDatas(bricksToExecute exinfra.Bricks, infra *exinfra.Infra) error {
-
 	// find all bricks that we need to ask output
 	var neededBricksForTheirOutputs exinfra.Bricks
 	for _, b := range bricksToExecute {

--- a/src/actions/debugActions.go
+++ b/src/actions/debugActions.go
@@ -20,19 +20,15 @@ func DebugArgs(
 }
 
 func DebugInfra(
-	infra *exinfra.Infra, conf *exargs.Configuration, bricksToExecute exinfra.Bricks) (
-	statusCode int, err error) {
-	statusCode = 0
-	fmt.Println(infra)
-	fmt.Printf("bricksToExecute:")
-	if len(bricksToExecute) == 0 {
-		fmt.Println(" []")
-	} else {
-		for _, b := range bricksToExecute {
-			fmt.Printf("\n  - %d:%s", b.Index, b.Name)
-		}
-		fmt.Println("")
-	}
+	infra *exinfra.Infra,
+	conf *exargs.Configuration,
+	bricksToExecute exinfra.Bricks,
+) (
+	statusCode int,
+	err error,
+) {
+	fmt.Printf("Infra:\n%v\n", infra)
+	fmt.Printf("bricksToExecute: [\n%v\n]", bricksToExecute)
 
 	return
 }

--- a/src/actions/default.go
+++ b/src/actions/default.go
@@ -10,7 +10,7 @@ import (
 // Ignores errors and calls the action in `args.Action` for every single brick,
 // then prints out a summary of it all.
 // Exit code matches 3 if an error occured, 0 otherwise.
-func Default(
+func PassthroughAction(
 	infra *exinfra.Infra,
 	conf *exargs.Configuration,
 	bricksToExecute exinfra.Bricks,

--- a/src/actions/default.go
+++ b/src/actions/default.go
@@ -33,10 +33,10 @@ func PassthroughAction(
 		statusCode, err = b.Module.Exec(b, conf.Action, conf.OtherOptions, []string{})
 
 		if err != nil {
-			if _, is := err.(exinfra.ActionNotImplementedError); is {
+			if actionNotImplementedError, isActionNotImplemented := err.(exinfra.ActionNotImplementedError); isActionNotImplemented {
 				// NOTE(half-shell): if action if not implemented, we don't take it as an error
 				// and move on with the execution
-				fmt.Printf("%v ; assume there is nothing to do.\n", err)
+				fmt.Printf("%v ; assume there is nothing to do.\n", actionNotImplementedError)
 				err = nil
 				report.Status = "OK"
 			} else {

--- a/src/actions/help.go
+++ b/src/actions/help.go
@@ -19,7 +19,7 @@ cd: change directory but you can use brick name althought path
 show: display brick attributes (depends of the format option choosen)
 clean: remove all files created by exeiac
 OPTIONS:
--I --non-interactive: run without interaction (use especially for ignore 
+-I --non-interactive: run without interaction (use especially for ignore
                       confirmation after lay or remove)
 -s --bricks-specifier: (selected|previous|following|children|this|
                         recursive-following|recursive-precedents)

--- a/src/actions/plan.go
+++ b/src/actions/plan.go
@@ -9,7 +9,7 @@ import (
 
 func Plan(
 	infra *exinfra.Infra,
-	args *exargs.Configuration,
+	conf *exargs.Configuration,
 	bricksToExecute exinfra.Bricks,
 ) (
 	statusCode int,

--- a/src/arguments/arguments.go
+++ b/src/arguments/arguments.go
@@ -6,6 +6,9 @@ import (
 	"strings"
 )
 
+// A struct matching the arguments available to be provided through the command line.
+// Used only to gather the command line arguments once parsed, and to be used as
+// a parameter to build a `Configuration` struct.
 type Arguments struct {
 	Action            string
 	BricksNames       []string
@@ -35,12 +38,14 @@ func (a Arguments) String() string {
 	return sb.String()
 }
 
-var actions_list = []string{
+// An array containing all of the supported actions
+var actions_list = [...]string{
 	"plan", "lay", "remove", "output", "init", "validate_code", "help",
 	"show_input", "list_elementary_bricks", "cd",
 	"get_brick_path", "get_brick_name"}
 
-var AvailableBricksSpecifiers = []string{
+// An array containing all of the supported brick's specifiers
+var AvailableBricksSpecifiers = [...]string{
 	"linked_previous", "all_previous", "lp", "ap",
 	"direct_previous", "dp",
 	"selected", "s",

--- a/src/arguments/arguments.go
+++ b/src/arguments/arguments.go
@@ -19,6 +19,7 @@ type Arguments struct {
 	OtherOptions      []string
 	Rooms             map[string]string
 	ConfigurationFile string
+	ShowUsage         bool
 }
 
 func (a Arguments) String() string {

--- a/src/arguments/configuration.go
+++ b/src/arguments/configuration.go
@@ -10,6 +10,8 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
+// A type matching the structure of exeiac's configuration file (`conf.yml`)
+// Its purpose is merely to load the configuration.
 type ConfigurationFile struct {
 	Rooms []struct {
 		Name string `yaml:"name"`
@@ -26,6 +28,11 @@ type ConfigurationFile struct {
 	} `yaml:"default_arguments"`
 }
 
+// A structure matching the `Arguments` type one. It is used to merge the values defined both
+// in the command lien with flags, and in the exeiac configuration file.
+//
+// NOTE(half-shell): Should be able to embed the ` Arguments` struct.
+// We replicate the `Arguments` since it does not seem to work out of the box for some reason.
 type Configuration struct {
 	Action            string
 	BricksNames       []string
@@ -89,6 +96,11 @@ func createConfiguration(confFilePath string) (configuration Configuration, err 
 	return
 }
 
+// Creates a `Configuration` struct resulting from the merger of the configuration file, and
+// the command lien arguments (`Arguments`).
+// Takes an instance of the `Arguments` struct as input that it can use to load the configuration file.
+// Returns a tuple of a configuration if successful, return an error as last member otherwise.
+//
 // NOTE(half-shell): We can change the behaviour of the configuration building
 // depending on a flag defined in "Arguments".
 // For instance: do we want to merge arguments or override them?

--- a/src/arguments/flags.go
+++ b/src/arguments/flags.go
@@ -1,0 +1,64 @@
+package arguments
+
+import (
+	"fmt"
+
+	flag "github.com/spf13/pflag"
+)
+
+var Args Arguments
+
+func init() {
+	flag.StringSliceVarP(&Args.BricksSpecifiers, "bricks-specifiers", "s", []string{"selected"},
+		fmt.Sprintf(`A list of comma separated specifiers.
+Includes: %v`, AvailableBricksSpecifiers))
+
+	flag.StringVarP(&Args.ConfigurationFile, "configuration-file", "c", "",
+		"A path the a valid configuration file")
+
+	flag.BoolVarP(&Args.NonInteractive, "non-interactive", "I", false,
+		"Allows for exeiac to run without user input")
+
+	flag.StringVarP(&Args.Format, "format", "f", "all",
+		fmt.Sprintf(`Define the format of the output. It matches the brick's specifiers values
+Includes: %v`, AvailableBricksSpecifiers))
+
+	defaultModules := make(map[string]string)
+	flag.StringToStringVarP(&Args.Modules, "modules", "m", defaultModules,
+		`A set of key/value pairs with the key being the name of the module,
+and the value its absolute path. This is useful if you want to setup
+a module on the command line. It uses the configuration file's modules
+declaration otherwise.`)
+
+	defaultRooms := make(map[string]string)
+	flag.StringToStringVarP(&Args.Rooms, "rooms", "r", defaultRooms,
+		`A set of key/value pairs with the key being the name of the room,
+and the value its absolute path. This is useful if you want to setup
+a room on the command line. It uses the configuration file's rooms
+declaration otherwise.`)
+
+	flag.StringSliceVarP(&Args.OtherOptions, "other-options", "o", []string{},
+		`A list of options to pass straight to the module. Useful to execute a
+module with an action not handled by exeiac, or to provide extra-options
+to it. Flag with arguments need to be enclosed in double quotes
+(e.g. -o "--myflag myargument",-b)`)
+
+	flag.BoolVarP(&Args.ShowUsage, "help", "h", false, "Show exeiac's help")
+
+	flag.Usage = func() {
+		fmt.Println("Usage: exeiac ACTION (BRICK_PATH|BRICK_NAME) [OPTION...]")
+		fmt.Println()
+		fmt.Println("ACTION:")
+		fmt.Println("  init: get some dependencies, typically download terraform modules or ansible deps")
+		fmt.Println("  plan: a dry run to check what we want to lay")
+		fmt.Println("  lay: lay the brick on the wall. Run the IaC with the right tools")
+		fmt.Println("  remove: remove a brick from your wall to destroy it properly.")
+		fmt.Println("  validate_code: validate if the syntaxe is ok")
+		fmt.Println("  help: display this help or the specified help for the brick")
+		fmt.Println("  show: display brick attributes (depends of the format option choosen)")
+		fmt.Println("  clean: remove all files created by exeiac")
+		fmt.Println()
+		fmt.Println("OPTION:")
+		flag.PrintDefaults()
+	}
+}

--- a/src/infra/brick.go
+++ b/src/infra/brick.go
@@ -7,7 +7,6 @@ import (
 	"log"
 	"os"
 	"path/filepath"
-	extools "src/exeiac/tools"
 	"strings"
 
 	"github.com/PaesslerAG/jsonpath"
@@ -104,29 +103,32 @@ func (bcy BrickConfYaml) New(path string) (BrickConfYaml, error) {
 }
 
 func (b Brick) String() string {
-	alwaysPresent := fmt.Sprintf(
-		"index: %d\nname: %s\npath: %s\nisElementary: %t\nconfFile: %s",
-		b.Index, b.Name, b.Path, b.IsElementary, b.ConfigurationFilePath)
+	var sb strings.Builder
 
-	conditional := "\n"
+	sb.WriteString(fmt.Sprintf("\tIndex: %d\n", b.Index))
+	sb.WriteString(fmt.Sprintf("\tName: %s\n", b.Name))
+	sb.WriteString(fmt.Sprintf("\tPath: %s\n", b.Path))
+	sb.WriteString(fmt.Sprintf("\tIsElementary: %v", b.IsElementary))
+
+	if len(b.ConfigurationFilePath) != 0 {
+		sb.WriteString(fmt.Sprintf("\n\tConfigurationFile: %s", b.ConfigurationFilePath))
+	}
+
 	if b.EnrichError != nil {
-		conditional = fmt.Sprintf("enrichError:%s\n", b.EnrichError)
+		sb.WriteString(fmt.Sprintf("\n\tEnrichError:%s", b.EnrichError))
 	}
 
 	if b.Module != nil {
-		conditional = fmt.Sprintf("%smodule:%s\n", conditional, b.Module.Name)
+		sb.WriteString(fmt.Sprintf("\n\tModule:%s", b.Module.Name))
 	}
 
 	if len(b.Inputs) > 0 {
-		dpStr := []string{}
-		for _, d := range b.Inputs {
-			dpStr = append(dpStr, d.String())
-		}
-		conditional = fmt.Sprintf("%sinputData:%s",
-			conditional, extools.StringListOfString(dpStr))
+		sb.WriteString(fmt.Sprintf("\n\tInputs: %v", b.Inputs))
 	}
 
-	return fmt.Sprintf("%s%s", alwaysPresent, conditional)
+	sb.WriteString("\n")
+
+	return sb.String()
 }
 
 func (brick *Brick) SetElementary(cfp string) *Brick {

--- a/src/infra/bricks.go
+++ b/src/infra/bricks.go
@@ -1,9 +1,16 @@
 package infra
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+)
 
 // A slice of several Brick.
 type Bricks []*Brick
+
+// A map of bricks, key being the brick's name, and the value being a reference to a `Brick` struct.
+// Defined as itw own type mainly for display purposes.
+type BricksMap map[string]*Brick
 
 // Allows for sorting over Bricks
 func (slice Bricks) Len() int {
@@ -18,6 +25,19 @@ func (slice Bricks) Less(i, j int) bool {
 // Allows for sorting over Bricks
 func (slice Bricks) Swap(i, j int) {
 	slice[i], slice[j] = slice[j], slice[i]
+}
+
+func (b Bricks) String() string {
+	var sb strings.Builder
+
+	for i, brick := range b {
+		sb.WriteString(fmt.Sprintf("- \t%d: %s", brick.Index, brick.Name))
+		if i < len(b)-1 {
+			sb.WriteString("\n")
+		}
+	}
+
+	return sb.String()
 }
 
 // Helper function to check wheither or not a brick was added to a slice of bricks
@@ -44,14 +64,12 @@ func RemoveDuplicates(bricks Bricks) Bricks {
 	return bs
 }
 
-func (b Bricks) String() string {
-	var str string
-	if len(b) > 0 {
-		for _, brick := range b {
-			str = fmt.Sprintf("%s\n- %s", str, brick.Name)
-		}
-	} else {
-		str = " []"
+func (b BricksMap) String() string {
+	var sb strings.Builder
+
+	for _, brick := range b {
+		sb.WriteString(fmt.Sprintf("- %v", brick))
 	}
-	return str
+
+	return sb.String()
 }

--- a/src/infra/infra.go
+++ b/src/infra/infra.go
@@ -17,7 +17,7 @@ import (
 
 type Infra struct {
 	Modules []Module
-	Bricks  map[string]*Brick
+	Bricks  BricksMap
 }
 
 func CreateInfra(configuration exargs.Configuration) (Infra, error) {
@@ -147,33 +147,19 @@ func GetBricks(roomName string, roomPath string) ([]Brick, error) {
 }
 
 func (infra Infra) String() string {
-	var modulesString string
-	var bricksString string
+	var sb strings.Builder
+	var modulesSb strings.Builder
+	var bricksSb strings.Builder
 
-	if len(infra.Modules) > 0 {
-		for _, m := range infra.Modules {
-			modulesString = fmt.Sprintf("%s%s", modulesString,
-				extools.IndentForListItem(m.String()))
-		}
-		modulesString = fmt.Sprintf("modules:\n%s", modulesString)
-	} else {
-		modulesString = "modules: []\n"
+	for _, m := range infra.Modules {
+		modulesSb.WriteString(fmt.Sprintf("%s", m))
 	}
 
-	if len(infra.Bricks) > 0 {
-		for _, b := range infra.Bricks {
-			bricksString = fmt.Sprintf("%s%s", bricksString,
-				extools.IndentForListItem(b.String()))
-		}
-		bricksString = fmt.Sprintf("bricks:\n%s", bricksString)
-	} else {
-		bricksString = "bricks: []\n"
-	}
+	bricksSb.WriteString(fmt.Sprintf("%v", infra.Bricks))
 
-	return fmt.Sprintf("infra:\n%s%s",
-		extools.Indent(modulesString),
-		extools.Indent(bricksString),
-	)
+	sb.WriteString(fmt.Sprintf("Modules: [\n%s]\nBricks:[\n%s]", modulesSb.String(), bricksSb.String()))
+
+	return sb.String()
 }
 
 func GetModule(name string, modules *[]Module) (*Module, error) {

--- a/src/infra/infra.go
+++ b/src/infra/infra.go
@@ -323,9 +323,12 @@ func (infra *Infra) GetBricksFromNames(names []string) (bricks Bricks, err error
 }
 
 func (infra *Infra) GetCorrespondingBricks(
-	bricks Bricks, specifiers []string) (
-	correspondingBricks Bricks, err error) {
-
+	bricks Bricks,
+	specifiers []string,
+) (
+	correspondingBricks Bricks,
+	err error,
+) {
 	var elementaryBricks Bricks
 	for _, brick := range bricks {
 		if !brick.IsElementary {

--- a/src/infra/infra.go
+++ b/src/infra/infra.go
@@ -430,7 +430,7 @@ func (infra *Infra) ValidateConfiguration(configuration *exargs.Configuration) (
 
 	// validate BricksSpecifiers
 	for _, specifier := range configuration.BricksSpecifiers {
-		if !extools.ContainsString(exargs.AvailableBricksSpecifiers, specifier) {
+		if !extools.ContainsString(exargs.AvailableBricksSpecifiers[:], specifier) {
 			return ErrBadArg{Reason: "Brick's specifier doesn't exist:", Value: specifier}
 		}
 	}

--- a/src/infra/infra.go
+++ b/src/infra/infra.go
@@ -417,7 +417,7 @@ func (infra *Infra) EnrichBricks() {
 	}
 }
 
-func (infra *Infra) ValidateConfiguration(configuration *exargs.Configuration) error {
+func (infra *Infra) ValidateConfiguration(configuration *exargs.Configuration) (err error) {
 	// validate brick names
 	for _, brickName := range configuration.BricksNames {
 		if _, ok := infra.Bricks[brickName]; !ok {

--- a/src/infra/module.go
+++ b/src/infra/module.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	extools "src/exeiac/tools"
+	"strings"
 )
 
 const ACTION_HELP = "help"
@@ -24,13 +25,13 @@ type Module struct {
 }
 
 func (m Module) String() string {
-	if len(m.Actions) > 0 {
-		return fmt.Sprintf("name: %s\npath: %s\nactions: %v\n",
-			m.Name, m.Path, m.Actions)
-	} else {
-		return fmt.Sprintf("name: %s\npath: %s\nactions: []",
-			m.Name, m.Path)
-	}
+	var sb strings.Builder
+
+	sb.WriteString(fmt.Sprintf("-\tName: %s\n", m.Name))
+	sb.WriteString(fmt.Sprintf("\tPath: %s\n", m.Path))
+	sb.WriteString(fmt.Sprintf("\tActions: %v\n", m.Actions))
+
+	return sb.String()
 }
 
 // Executes the ACTION_SHOW_AVAILABLE_ACTIONS command on a module to get


### PR DESCRIPTION
# Changes
- (minor) Pull out `flag.Parse()` to the main's `init()` function
- Add a `-h - flag
```
brk@roger ~/> exeiac -h
Usage: exeiac ACTION (BRICK_PATH|BRICK_NAME) [OPTION...]

ACTION:
  init: get some dependencies, typically download terraform modules or ansible deps
  plan: a dry run to check what we want to lay
  lay: lay the brick on the wall. Run the IaC with the right tools
  remove: remove a brick from your wall to destroy it properly.
  validate_code: validate if the syntaxe is ok
  help: display this help or the specified help for the brick
  show: display brick attributes (depends of the format option choosen)
  clean: remove all files created by exeiac

OPTION:
  -s, --bricks-specifiers strings   A list of comma separated specifiers.
                                    Includes: [linked_previous all_previous lp ap direct_previous dp selected s direct_next dn linked_next all_next ln an] (default [selected])
  -c, --configuration-file string   A path the a valid configuration file (default "/etc/exeiac/conf.yml")
  -f, --format string               Define the format of the output. It matches the brick's specifiers values
                                    Includes: [linked_previous all_previous lp ap direct_previous dp selected s direct_next dn linked_next all_next ln an] (default "all")
  -h, --help                        Show exeiac's help
  -m, --modules stringToString      A set of key/value pairs with the key being the name of the module,
                                    and the value its absolute path. This is useful if you want to setup
                                    a module on the command line. It uses the configuration file's modules
                                    declaration otherwise. (default [])
  -I, --non-interactive             Allows for exeiac to run without user input
  -o, --other-options strings       A list of options to pass straight to the module. Useful to execute a
                                    module with an action not handled by exeiac, or to provide extra-options
                                    to it. Flag with arguments need to be enclosed in double quotes
                                    (e.g. -o "--myflag myargument",-b)
  -r, --rooms stringToString        A set of key/value pairs with the key being the name of the room,
                                    and the value its absolute path. This is useful if you want to setup
                                    a room on the command line. It uses the configuration file's rooms
                                    declaration otherwise. (default [])
```