### PR TITLE
feat: add an interactive flag to override configuration setting

### DIFF
--- a/src/arguments/arguments.go
+++ b/src/arguments/arguments.go
@@ -14,6 +14,7 @@ type Arguments struct {
 	BricksNames       []string
 	BricksSpecifiers  []string
 	NonInteractive    bool
+	Interactive       bool
 	Format            string
 	Modules           map[string]string
 	OtherOptions      []string

--- a/src/arguments/configuration.go
+++ b/src/arguments/configuration.go
@@ -164,7 +164,7 @@ func FromArguments(args Arguments) (configuration Configuration, err error) {
 		BricksSpecifiers:  extools.Deduplicate(append(conf.BricksSpecifiers, args.BricksSpecifiers...)),
 		ConfigurationFile: args.ConfigurationFile,
 		Format:            args.Format,
-		Interactive:       !args.NonInteractive,
+		Interactive:       (conf.Interactive && !args.NonInteractive) || args.Interactive,
 		Modules:           modules,
 		Rooms:             rooms,
 		OtherOptions:      other_options,

--- a/src/arguments/flags.go
+++ b/src/arguments/flags.go
@@ -19,6 +19,9 @@ Includes: %v`, AvailableBricksSpecifiers))
 	flag.BoolVarP(&Args.NonInteractive, "non-interactive", "I", false,
 		"Allows for exeiac to run without user input")
 
+	flag.BoolVarP(&Args.Interactive, "interactive", "i", false,
+		"Forces exeiac to wait for user input when needed. Overwrites the --non-interactive (-I) flag.")
+
 	flag.StringVarP(&Args.Format, "format", "f", "all",
 		fmt.Sprintf(`Define the format of the output. It matches the brick's specifiers values
 Includes: %v`, AvailableBricksSpecifiers))


### PR DESCRIPTION
This flag is implemented to handle the following use case.

As a user, I have the `NonInteractive` flag set to `true` in my `exeiac.yml` and I want to be able to remove the `--non-interactive` flag for a single command.

The idea is to provide the user with a `-i` flag that would allow him to override the value provided in his configuration file, since it wouldn't be possible otherwise, considering the value set there takes precedence over the default value of `arg.NonInteractive` when no flag is provided.