### PR TITLE
Fix/dependency enrich error

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,25 @@
-# exeiac
+# Exeiac
 
-execute infra code smartly by :
-- trying to solve dependency issues
-- being transparent on how to deploy a part of your infra (no matter if you
-  use terraform or ansible or... you will use the same interface)
-- permit proper shortcut that don't break dependency tree even if it's not
-  easily managed by your tool
+## Description
+`exeiac` is a tool that enables infrastructure folks to handle several
+different provisionning IaC (Infrastructure as Code) tools, under a
+single CLI, and helps solving some recurrent paintpoints with IaC.
 
-exeiac use the brick metaphor. It describes infra as a set of bricks. A brick
-is a part of infra (the real infra element, the code that describes it, the code
-that permits to execute it). It can be a terraform state, an ansible playbook,
-a helm chart...
+It follows the brick convention, which describes an infrastructure as
+a set of bricks. A brick is a piece of infrastructure, it
+simultaneously is the actual infrastructure element, the code that
+describes it and a piece code that allows its execution; be it a
+terraform state, an ansible playbook or a helm chart for instance.
+
+This project was born from the following needs:
+- solve dependencies issues
+- increase transparency as to how a piece of infrastructure should be
+    deployed. No matter the provisionning tool you use, if there's a
+    module for it, `exeiac` will handle it
+- allow for a clean way to interact with only a part of your
+  infrastructure in a safe way, without breaking the dependency tree,
+  even if your infrastructure management tool doesn't provide that
+  feature
 
 ## DOCUMENTATION
 
@@ -26,9 +35,23 @@ a helm chart...
   respect the convention and best practices
 - examples: examples of simple infra code and module
 
-## HOW TO
+## Get started
 
-For using exeiac you will have to:
+### Installation
+
+Clone the git repository and build:
+``` bash
+$ git clone github.com/arthur91f/exeiac/src/exeiac
+$ cd exeiac
+$ go install src/exeiac
+```
+
+There is no release process yet, but on Go version 1.16 or later you can:
+``` bash
+# Install at tree head:
+$ go install github.com/arthur91f/exeiac/src/exeiac/src/exeiac@main
+```
+
 - get the exeiac binary
 - have an infra code that follow some conventions (see below for more details)
   - each brick is a directory prefixed by a number to make the apply order
@@ -48,15 +71,6 @@ For using exeiac you will have to:
     - $HOME/git-repos/applications
     - $HOME/git-repos/users
   ```
-
-### Compile
-
-Once cloned and in the repo directory, you'll be able to compile the project by
-running the following command:
-```bash
-go build src/exeiac
-```
-
 ### Simple command line examples
 
 - display a brick output
@@ -125,9 +139,9 @@ action. You can also implement other personal action.
     needed for execute the brick
   - show --format direct-next: display the list of bricks that needs the output
     of the specified bricks
-  - show --format linked-previous: display the list of bricks that needs to be 
+  - show --format linked-previous: display the list of bricks that needs to be
     layed to lay your brick (as their outputs are needed directly or not)
-  - show --format linked-next: display the list of bricks that can be impacted 
+  - show --format linked-next: display the list of bricks that can be impacted
     recursively by a change in your brick
-  - show --children: display elementary bricks 
+  - show --children: display elementary bricks
   - ... others exeiac command in general

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ $ go install github.com/arthur91f/exeiac/src/exeiac/src/exeiac@main
   - each elementary brick should reference in brick.yml an executable or module
     to execute itself. (a module is simply an executable that is not in the
     brick directory and that can be called by many bricks)
-- create a conf file in /etc/exeiac.conf or $HOME/.exeiac.conf
+- create a conf file in /etc/exeiac/exeiac.yml or $HOME/.config/exeiac.yml
   ```yaml
   modules_path:
     terraform: $HOME/git-repos/exeiac-modules/terraform

--- a/docs/development/get_started.md
+++ b/docs/development/get_started.md
@@ -1,0 +1,19 @@
+# Development
+This document gather the bare minimum to get this repo going locally.
+
+## Cloning the repo
+```bash
+$ git clone github.com/arthur91f/exeiac/src/exeiac
+```
+
+## Compiling
+Once cloned and in the repo directory, you'll be able to compile the project by
+running the following command:
+```bash
+$ go build src/exeiac
+# and then
+$ ./main -h
+
+# You can also
+$ go run src/exeiac -h
+```

--- a/example/exeiac.yml
+++ b/example/exeiac.yml
@@ -1,19 +1,19 @@
 modules:
   - name: test
-    path: /home/ME/git/exeiac/example/repos/modules/module_test.sh
+    path: ./repos/modules/module_test.sh
   - name: terraform
-    path: /home/ME/git/exeiac/example/repos/modules/terraform.sh
+    path: ./repos/modules/terraform.sh
   - name: manual-module
-    path: /home/ME/git/exeiac/example/repos/modules/manual-module.sh
+    path: ./repos/modules/manual-module.sh
 rooms:
   - name: infra-ground
-    path: /home/ME/git/exeiac/example/repos/infra-grounds
+    path: ./repos/infra-grounds
   - name: app-a
-    path: /home/ME/git/exeiac/example/repos/app-backend-a
+    path: ./repos/app-backend-a
   - name: app-b
-    path: /home/ME/git/exeiac/example/repos/app-frontend-b
+    path: ./repos/app-frontend-b
   - name: users
-    path: /home/ME/git/exeiac/example/repos/infra-users
+    path: ./repos/infra-users
 default_arguments:
   other_options:
     - "--test-args 0+0=toto"

--- a/example/repos/infra-users/1-monitoring/1-bastion/brick.yml
+++ b/example/repos/infra-users/1-monitoring/1-bastion/brick.yml
@@ -6,13 +6,13 @@ input:
     path: ""
     data:
       - name: EXEIAC_TEST_admins_group
-        from: infra-users/users_and_groups:$.groups.admin
+        from: users/users_and_groups:$.groups.admin
       - name: EXEIAC_TEST_ops_group
-        from: infra-users/users_and_groups:$.groups.ops
+        from: users/users_and_groups:$.groups.ops
       - name: EXEIAC_TEST_devs_groups
-        from: infra-users/users_and_groups:$.groups.dev
+        from: users/users_and_groups:$.groups.dev
       - name: EXEIAC_TEST_products_groups
-        from: infra-users/users_and_groups:$.groups.product
+        from: users/users_and_groups:$.groups.product
       - name: EXEIAC_TEST_bastion_dns
         from: infra-ground/envs/monitoring/bastion:$.bastion.internal_domain_name
         weak_dependency: true

--- a/example/repos/infra-users/1-monitoring/1-grafana/brick.yml
+++ b/example/repos/infra-users/1-monitoring/1-grafana/brick.yml
@@ -6,13 +6,13 @@ input:
     path: ""
     data:
       - name: EXEIAC_TEST_admins_group
-        from: infra-users/users_and_groups:$.groups.admin
+        from: users/users_and_groups:$.groups.admin
       - name: EXEIAC_TEST_ops_group
-        from: infra-users/users_and_groups:$.groups.ops
+        from: users/users_and_groups:$.groups.ops
       - name: EXEIAC_TEST_devs_groups
-        from: infra-users/users_and_groups:$.groups.dev
+        from: users/users_and_groups:$.groups.dev
       - name: EXEIAC_TEST_products_groups
-        from: infra-users/users_and_groups:$.groups.product
+        from: users/users_and_groups:$.groups.product
       - name: EXEIAC_TEST_bastion
         from: infra-ground/envs/monitoring/bastion:$.bastion.internal_domain_name
       - name: EXEIAC_TEST_grafana

--- a/example/repos/infra-users/1-production/1-bastion/brick.yml
+++ b/example/repos/infra-users/1-production/1-bastion/brick.yml
@@ -10,9 +10,9 @@ input:
       - name: TF_VAR_env_name
         from: infra-ground/init/create_accounts:$.projects.production.env
       - name: EXEIAC_TEST_admins_group
-        from: infra-users/users_and_groups:$.groups.admin
+        from: users/users_and_groups:$.groups.admin
       - name: EXEIAC_TEST_ops_group
-        from: infra-users/users_and_groups:$.groups.ops
+        from: users/users_and_groups:$.groups.ops
       - name: EXEIAC_TEST_bastion_dns
         from: infra-ground/envs/production/bastion:$.bastion.internal_domain_name
         weak_dependency: true

--- a/example/repos/infra-users/1-production/1-cluster_k8s/brick.yml
+++ b/example/repos/infra-users/1-production/1-cluster_k8s/brick.yml
@@ -10,8 +10,8 @@ input:
       - name: TF_VAR_env_name
         from: infra-ground/init/create_accounts:$.projects.production.env
       - name: EXEIAC_TEST_admins_group
-        from: infra-users/users_and_groups:$.groups.admin
+        from: users/users_and_groups:$.groups.admin
       - name: EXEIAC_TEST_ops_group
-        from: infra-users/users_and_groups:$.groups.ops
+        from: users/users_and_groups:$.groups.ops
       - name: EXEIAC_TEST_cluster_id
         from: infra-ground/envs/production/cluster_k8s:$.cluster.instance_id

--- a/example/repos/infra-users/1-production/1-database/brick.yml
+++ b/example/repos/infra-users/1-production/1-database/brick.yml
@@ -10,8 +10,8 @@ input:
       - name: TF_VAR_env_name
         from: infra-ground/init/create_accounts:$.projects.production.env
       - name: EXEIAC_TEST_admins_group
-        from: infra-users/users_and_groups:$.groups.admin
+        from: users/users_and_groups:$.groups.admin
       - name: EXEIAC_TEST_ops_group
-        from: infra-users/users_and_groups:$.groups.ops
+        from: users/users_and_groups:$.groups.ops
       - name: EXEIAC_TEST_database
         from: infra-ground/envs/production/database:$.*

--- a/example/repos/infra-users/1-staging/1-bastion/brick.yml
+++ b/example/repos/infra-users/1-staging/1-bastion/brick.yml
@@ -10,13 +10,13 @@ input:
       - name: TF_VAR_env_name
         from: infra-ground/init/create_accounts:$.projects.staging.env
       - name: EXEIAC_TEST_admins_group
-        from: infra-users/users_and_groups:$.groups.admin
+        from: users/users_and_groups:$.groups.admin
       - name: EXEIAC_TEST_ops_group
-        from: infra-users/users_and_groups:$.groups.ops
+        from: users/users_and_groups:$.groups.ops
       - name: EXEIAC_TEST_devs_groups
-        from: infra-users/users_and_groups:$.groups.dev
+        from: users/users_and_groups:$.groups.dev
       - name: EXEIAC_TEST_products_groups
-        from: infra-users/users_and_groups:$.groups.product
+        from: users/users_and_groups:$.groups.product
       - name: EXEIAC_TEST_bastion_dns
         from: infra-ground/envs/staging/bastion:$.bastion.internal_domain_name
         weak_dependency: true

--- a/example/repos/infra-users/1-staging/1-cluster_k8s/brick.yml
+++ b/example/repos/infra-users/1-staging/1-cluster_k8s/brick.yml
@@ -10,10 +10,10 @@ input:
       - name: TF_VAR_env_name
         from: infra-ground/init/create_accounts:$.projects.staging.env
       - name: EXEIAC_TEST_admins_group
-        from: infra-users/users_and_groups:$.groups.admin
+        from: users/users_and_groups:$.groups.admin
       - name: EXEIAC_TEST_ops_group
-        from: infra-users/users_and_groups:$.groups.ops
+        from: users/users_and_groups:$.groups.ops
       - name: EXEIAC_TEST_devs_groups
-        from: infra-users/users_and_groups:$.groups.dev
+        from: users/users_and_groups:$.groups.dev
       - name: EXEIAC_TEST_cluster_id
         from: infra-ground/envs/staging/cluster_k8s:$.cluster.instance_id

--- a/example/repos/infra-users/1-staging/1-database/brick.yml
+++ b/example/repos/infra-users/1-staging/1-database/brick.yml
@@ -10,12 +10,12 @@ input:
       - name: TF_VAR_env_name
         from: infra-ground/init/create_accounts:$.projects.staging.env
       - name: EXEIAC_TEST_admins_group
-        from: infra-users/users_and_groups:$.groups.admin
+        from: users/users_and_groups:$.groups.admin
       - name: EXEIAC_TEST_ops_group
-        from: infra-users/users_and_groups:$.groups.ops
+        from: users/users_and_groups:$.groups.ops
       - name: EXEIAC_TEST_devs_groups
-        from: infra-users/users_and_groups:$.groups.dev
+        from: users/users_and_groups:$.groups.dev
       - name: EXEIAC_TEST_products_groups
-        from: infra-users/users_and_groups:$.groups.product
+        from: users/users_and_groups:$.groups.product
       - name: EXEIAC_TEST_database
         from: infra-ground/envs/staging/database:$.*

--- a/src/arguments/arguments.go
+++ b/src/arguments/arguments.go
@@ -10,18 +10,18 @@ import (
 // Used only to gather the command line arguments once parsed, and to be used as
 // a parameter to build a `Configuration` struct.
 type Arguments struct {
-	Action            string
-	BricksNames       []string
-	BricksSpecifiers  []string
-	NonInteractive    bool
-	Interactive       bool
-	Format            string
-	Modules           map[string]string
-	OtherOptions      []string
-	Rooms             map[string]string
-	ConfigurationFile string
-	ShowUsage         bool
-	ListBricks        bool
+	Action                string
+	BricksNames           []string
+	BricksSpecifiers      []string
+	NonInteractive        bool
+	Interactive           bool
+	Format                string
+	Modules               map[string]string
+	OtherOptions          []string
+	Rooms                 map[string]string
+	ConfigurationFilePath string
+	ShowUsage             bool
+	ListBricks            bool
 }
 
 func (a Arguments) String() string {

--- a/src/arguments/flags.go
+++ b/src/arguments/flags.go
@@ -13,7 +13,7 @@ func init() {
 		fmt.Sprintf(`A list of comma separated specifiers.
 Includes: %v`, AvailableBricksSpecifiers))
 
-	flag.StringVarP(&Args.ConfigurationFile, "configuration-file", "c", "",
+	flag.StringVarP(&Args.ConfigurationFilePath, "configuration-file", "c", "",
 		"A path the a valid configuration file")
 
 	flag.BoolVarP(&Args.NonInteractive, "non-interactive", "I", false,

--- a/src/infra/brick.go
+++ b/src/infra/brick.go
@@ -159,6 +159,8 @@ func (brick *Brick) Enrich(bcy BrickConfYaml, infra *Infra) error {
 	dependencies, err := bcy.resolveDependencies(infra)
 	if err != nil {
 		log.Printf("An error occured when getting dependencies of brick %s: %v\n", brick.Name, err)
+
+		return err
 	}
 
 	brick.Inputs = dependencies

--- a/src/infra/brick.go
+++ b/src/infra/brick.go
@@ -239,7 +239,9 @@ func (b *Brick) CreateFormatters() (fileFormatters map[string]Formatter, env_for
 func (bcy BrickConfYaml) resolveDependencies(infra *Infra) (inputs []Input, err error) {
 	parseFromField := func(from string) (brickName string, dataKey string, err error) {
 		if from == "" {
-			return "", "", fmt.Errorf("field from is empty or doesn't exist")
+			err = fmt.Errorf("field from is empty or doesn't exist")
+
+			return
 		}
 
 		fields := strings.Split(from, ":")

--- a/src/infra/infra.go
+++ b/src/infra/infra.go
@@ -41,7 +41,7 @@ func CreateInfra(configuration exargs.Configuration) (Infra, error) {
 	for name, path := range configuration.Rooms {
 		b, err := GetBricks(name, path)
 		if err != nil {
-			fmt.Printf(`Cannot add "%s" (path: %s) room's bricks: %s`, name, path, err)
+			fmt.Printf("Cannot add \"%s\" (path: %s) room's bricks: %v\n", name, path, err)
 		}
 
 		bricks = append(bricks, b...)


### PR DESCRIPTION
Changes:
* fixes #91
* fix example infra `user-and-groups` naming to match the dependencies 
* Improve error display by adding a line jump
* change configuration path's name to be more explicit. Replace `Configuration.ConfigurationFile` with `Configuration.ConfigurationFilePath`